### PR TITLE
Part 1 kotling-stats command: User's mention statistics

### DIFF
--- a/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
@@ -17,7 +17,7 @@ class KotlinMentionsDAO(
     @Volatile
     private var initialized = false
 
-    suspend fun updateKotlinMentionInfo(id: String, userId: String, instant: Instant) {
+    suspend fun updateKotlinMentionInfo(id: String, userId: String) {
         val builder = UpdateItemRequest.builder()
                 .tableName(table)
                 .key(mapOf(ID_ATTR to AttributeValue.builder().s(id).build()))

--- a/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
@@ -14,23 +14,16 @@ class KotlinMentionsDAO(
         private const val ID_ATTR = "chatId"
     }
 
-    @Volatile
-    private var initialized = false
-
     suspend fun updateKotlinMentionInfo(id: String, userId: String) {
         val builder = UpdateItemRequest.builder()
                 .tableName(table)
                 .key(mapOf(ID_ATTR to AttributeValue.builder().s(id).build()))
 
-        if (!initialized) {
-            // small optimization: create "users" map attr only once, because it's top level attribute
-            dynamoDb.updateItem(builder.applyMutation {
-                it.updateExpression("SET #u = if_not_exists(#u, :empty)")
-                it.expressionAttributeNames(mapOf("#u" to "users"))
-                it.expressionAttributeValues(mapOf(":empty" to AttributeValue.builder().m(mapOf()).build()))
-            }.build()).await()
-            initialized = true
-        }
+        dynamoDb.updateItem(builder.applyMutation {
+            it.updateExpression("SET #u = if_not_exists(#u, :empty)")
+            it.expressionAttributeNames(mapOf("#u" to "users"))
+            it.expressionAttributeValues(mapOf(":empty" to AttributeValue.builder().m(mapOf()).build()))
+        }.build()).await()
 
         dynamoDb.updateItem(builder.applyMutation {
             it.updateExpression("SET #u.#user_id = if_not_exists(#u.#user_id, :empty)")

--- a/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
@@ -34,10 +34,7 @@ class KotlinMentionsDAO(
 
         dynamoDb.updateItem(builder.applyMutation {
             it.updateExpression("SET #u.#user_id = if_not_exists(#u.#user_id, :empty)")
-            it.expressionAttributeNames(mapOf(
-                    "#u" to "users",
-                    "#user_id" to userId)
-            )
+            it.expressionAttributeNames(mapOf("#u" to "users", "#user_id" to userId))
             it.expressionAttributeValues(mapOf(":empty" to AttributeValue.builder().m(mapOf(
                     "count" to AttributeValue.builder().n("0").build(),
                     "last_time" to AttributeValue.builder().n("0").build()
@@ -54,12 +51,10 @@ class KotlinMentionsDAO(
                     "#t" to "timestamp",
                     "#c" to "count",
                     "#u" to "users",
-                    "#user_id" to userId)
-            )
+                    "#user_id" to userId))
             it.expressionAttributeValues(mapOf(
                     ":last_time" to AttributeValue.builder().n(Instant.now().toEpochMilli().toString()).build(),
-                    ":inc" to AttributeValue.builder().n("1").build()
-            ))
+                    ":inc" to AttributeValue.builder().n("1").build()))
         }.build())
     }
 

--- a/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
@@ -17,7 +17,7 @@ class KotlinMentionsDAO(
     @Volatile
     private var initialized = false
 
-    suspend fun updateKotlinLastMentionAt(id: String, userId: String, instant: Instant) {
+    suspend fun updateKotlinMentionInfo(id: String, userId: String, instant: Instant) {
         val builder = UpdateItemRequest.builder()
                 .tableName(table)
                 .key(mapOf(ID_ATTR to AttributeValue.builder().s(id).build()))

--- a/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
@@ -3,6 +3,7 @@ package by.jprof.telegram.opinions.dao
 import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
 import java.time.Instant
 
 class KotlinMentionsDAO(
@@ -11,28 +12,66 @@ class KotlinMentionsDAO(
 ) {
     companion object {
         private const val ID_ATTR = "chatId"
-        private const val VALUE_ATTR = "timestamp"
     }
 
+    @Volatile
+    private var initialized = false
+
     suspend fun updateKotlinLastMentionAt(id: String, userId: String, instant: Instant) {
-        dynamoDb.putItem {
-            it.tableName(table)
-            it.item(
-                    mapOf(
-                            ID_ATTR to AttributeValue.builder().s(id).build(),
-                            VALUE_ATTR to AttributeValue.builder().n(instant.toEpochMilli().toString()).build()
-                    )
+        val builder = UpdateItemRequest.builder()
+                .tableName(table)
+                .key(mapOf(ID_ATTR to AttributeValue.builder().s(id).build()))
+
+        if (!initialized) {
+            // small optimization: create "users" map attr only once, because it's top level attribute
+            dynamoDb.updateItem(builder.applyMutation {
+                it.updateExpression("SET #u = if_not_exists(#u, :empty)")
+                it.expressionAttributeNames(mapOf("#u" to "users"))
+                it.expressionAttributeValues(mapOf(":empty" to AttributeValue.builder().m(mapOf()).build()))
+            }.build()).await()
+            initialized = true
+        }
+
+        dynamoDb.updateItem(builder.applyMutation {
+            it.updateExpression("SET #u.#user_id = if_not_exists(#u.#user_id, :empty)")
+            it.expressionAttributeNames(mapOf(
+                    "#u" to "users",
+                    "#user_id" to userId)
             )
-        }.await()
+            it.expressionAttributeValues(mapOf(":empty" to AttributeValue.builder().m(mapOf(
+                    "count" to AttributeValue.builder().n("0").build(),
+                    "last_time" to AttributeValue.builder().n("0").build()
+            )).build()))
+        }.build()).await()
+
+        dynamoDb.updateItem(builder.applyMutation {
+            it.updateExpression("""
+                SET #u.#user_id.#c = #u.#user_id.#c + :inc,
+                    #u.#user_id.last_time = :last_time,
+                    #t = :last_time
+            """.trimIndent())
+            it.expressionAttributeNames(mapOf(
+                    "#t" to "timestamp",
+                    "#c" to "count",
+                    "#u" to "users",
+                    "#user_id" to userId)
+            )
+            it.expressionAttributeValues(mapOf(
+                    ":last_time" to AttributeValue.builder().n(Instant.now().toEpochMilli().toString()).build(),
+                    ":inc" to AttributeValue.builder().n("1").build()
+            ))
+        }.build())
     }
 
     suspend fun getKotlinLastMentionAt(id: String): Instant? {
         return dynamoDb.getItem {
             it.tableName(table)
             it.key(mapOf(ID_ATTR to AttributeValue.builder().s(id).build()))
+            it.projectionExpression("#t")
+            it.expressionAttributeNames(mapOf("#t" to "timestamp"))
         }.await()?.item()?.takeUnless { it.isEmpty() }
                 ?.let {
-                    val epoch = it[VALUE_ATTR] ?: throw IllegalStateException("Missing $VALUE_ATTR property")
+                    val epoch = it["timestamp"] ?: throw IllegalStateException("Missing 'timestamp' property")
                     Instant.ofEpochMilli(epoch.n().toLong())
                 }
     }

--- a/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/dao/KotlinMentionsDAO.kt
@@ -14,7 +14,7 @@ class KotlinMentionsDAO(
         private const val VALUE_ATTR = "timestamp"
     }
 
-    suspend fun updateKotlinLastMentionAt(id: String, instant: Instant) {
+    suspend fun updateKotlinLastMentionAt(id: String, userId: String, instant: Instant) {
         dynamoDb.putItem {
             it.tableName(table)
             it.item(

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -56,16 +56,21 @@ class KotlinMentionsProcessor(
         val lastTime = kotlinMentionsDAO.getKotlinLastMentionAt(chatId.toString())
                 ?: return sendSticker(chatId, userId, contentMessage.messageId)
 
-        val duration = Duration.between(lastTime, Instant.now())
-        if (!hasPassedEnoughTimeSincePreviousMention(duration)) {
-            return
-        }
+        val duration = computeDurationIfPassedEnoughTime(lastTime) ?: return
 
         sendSticker(chatId, userId, contentMessage.messageId) {
             bot.sendTextMessage(chatId.toChatId(),
                     composeStickerMessage(duration),
                     replyToMessageId = it.messageId)
         }
+    }
+
+    private fun computeDurationIfPassedEnoughTime(lastTime: Instant): Duration? {
+        val duration = Duration.between(lastTime, Instant.now())
+        if (hasPassedEnoughTimeSincePreviousMention(duration)) {
+            return duration
+        }
+        return null
     }
 
     private suspend fun sendSticker(

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -47,17 +47,12 @@ class KotlinMentionsProcessor(
         val message = (update as? MessageUpdate) ?: return
         val contentMessage = (message.data as? CommonMessageImpl<*>) ?: return
         val textContent = (contentMessage.content as? TextContent) ?: return
-
         if (!containsMatchIn(textContent.text)) return
-
         val chatId = contentMessage.chat.id.chatId
         val userId = contentMessage.user.id.chatId
-
         val lastTime = kotlinMentionsDAO.getKotlinLastMentionAt(chatId.toString())
                 ?: return sendSticker(chatId, userId, contentMessage.messageId)
-
         val duration = computeDurationIfPassedEnoughTime(lastTime) ?: return
-
         sendSticker(chatId, userId, contentMessage.messageId) {
             bot.sendTextMessage(chatId.toChatId(),
                     composeStickerMessage(duration),

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -7,6 +7,7 @@ import com.github.insanusmokrassar.TelegramBotAPI.extensions.api.send.sendTextMe
 import com.github.insanusmokrassar.TelegramBotAPI.requests.abstracts.toInputFile
 import com.github.insanusmokrassar.TelegramBotAPI.types.ChatId
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageIdentifier
+import com.github.insanusmokrassar.TelegramBotAPI.types.message.CommonMessageImpl
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.abstracts.ContentMessage
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextContent
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.media.StickerContent
@@ -43,7 +44,7 @@ class KotlinMentionsProcessor(
 
     override suspend fun process(update: Update) {
         val message = (update as? MessageUpdate) ?: return
-        val contentMessage = (message.data as? ContentMessage<*>) ?: return
+        val contentMessage = (message.data as? CommonMessageImpl<*>) ?: return
         val textContent = (contentMessage.content as? TextContent) ?: return
 
         if (!containsMatchIn(textContent.text)) return

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -51,10 +51,11 @@ class KotlinMentionsProcessor(
         if (!containsMatchIn(textContent.text)) return
 
         val chatId = contentMessage.chat.id.chatId
+        val userId = contentMessage.user.id.chatId
 
         val lastTime = kotlinMentionsDAO.getKotlinLastMentionAt(chatId.toString())
         if (lastTime == null) {
-            sendSticker(chatId, contentMessage.messageId)
+            sendSticker(chatId, userId, contentMessage.messageId)
             return
         }
 
@@ -63,7 +64,7 @@ class KotlinMentionsProcessor(
             return
         }
 
-        sendSticker(chatId, contentMessage.messageId) {
+        sendSticker(chatId, userId, contentMessage.messageId) {
             bot.sendTextMessage(chatId.toChatId(),
                     composeStickerMessage(duration),
                     replyToMessageId = it.messageId)
@@ -72,6 +73,7 @@ class KotlinMentionsProcessor(
 
     private suspend fun sendSticker(
             chatId: Identifier,
+            userId: Identifier,
             messageId: MessageIdentifier,
             onSend: suspend (ContentMessage<StickerContent>) -> Unit = {}
     ) {
@@ -84,6 +86,6 @@ class KotlinMentionsProcessor(
         onSend(response)
 
         kotlinMentionsDAO.updateKotlinLastMentionAt(
-                chatId.toString(), Instant.now())
+                chatId.toString(), userId.toString(), Instant.now())
     }
 }

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -54,10 +54,7 @@ class KotlinMentionsProcessor(
         val userId = contentMessage.user.id.chatId
 
         val lastTime = kotlinMentionsDAO.getKotlinLastMentionAt(chatId.toString())
-        if (lastTime == null) {
-            sendSticker(chatId, userId, contentMessage.messageId)
-            return
-        }
+                ?: return sendSticker(chatId, userId, contentMessage.messageId)
 
         val duration = Duration.between(lastTime, Instant.now())
         if (!hasPassedEnoughTimeSincePreviousMention(duration)) {

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -27,7 +27,7 @@ class KotlinMentionsProcessor(
         private val composeStickerMessage: (Duration) -> String = ::composeStickerMessage
 ) : UpdateProcessor {
     companion object {
-        const val zeroDaysWithoutKotlinStickerFileId = "CAACAgIAAxkBAAIBsF8V0dPb6EesBKSujFFOx_URfhSdAAJAAQACqSImBOs5DmSNtKlmGgQ"
+        private const val zeroDaysWithoutKotlinStickerFileId = "CAACAgIAAxkBAAIBsF8V0dPb6EesBKSujFFOx_URfhSdAAJAAQACqSImBOs5DmSNtKlmGgQ"
         private val kotlinRegex = "([kк]+.{0,5}[оo0aа]+.{0,5}[тt]+.{0,5}[лl]+.{0,5}[ие1ie]+.{0,5}[нnH]+)".toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.MULTILINE))
         private val minRequiredDelayBetweenReplies: Duration = Duration.ofMinutes(30)!!
         private val maxRequiredDelayBetweenReplies: Duration = Duration.ofHours(1)!!

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -5,12 +5,13 @@ import com.github.insanusmokrassar.TelegramBotAPI.bot.RequestsExecutor
 import com.github.insanusmokrassar.TelegramBotAPI.extensions.api.send.media.sendSticker
 import com.github.insanusmokrassar.TelegramBotAPI.extensions.api.send.sendTextMessage
 import com.github.insanusmokrassar.TelegramBotAPI.requests.abstracts.toInputFile
-import com.github.insanusmokrassar.TelegramBotAPI.types.ChatId
+import com.github.insanusmokrassar.TelegramBotAPI.types.Identifier
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageIdentifier
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.CommonMessageImpl
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.abstracts.ContentMessage
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextContent
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.media.StickerContent
+import com.github.insanusmokrassar.TelegramBotAPI.types.toChatId
 import com.github.insanusmokrassar.TelegramBotAPI.types.update.MessageUpdate
 import com.github.insanusmokrassar.TelegramBotAPI.types.update.abstracts.Update
 import java.time.Duration
@@ -49,12 +50,12 @@ class KotlinMentionsProcessor(
 
         if (!containsMatchIn(textContent.text)) return
 
-        val id = contentMessage.chat.id.chatId.toString()
+        val chatId = contentMessage.chat.id.chatId
 
-        val lastTime = kotlinMentionsDAO.getKotlinLastMentionAt(id)
+        val lastTime = kotlinMentionsDAO.getKotlinLastMentionAt(chatId.toString())
         if (lastTime == null) {
-            sendSticker(contentMessage.chat.id, contentMessage.messageId)
-            kotlinMentionsDAO.updateKotlinLastMentionAt(id, Instant.now())
+            sendSticker(chatId, contentMessage.messageId)
+            kotlinMentionsDAO.updateKotlinLastMentionAt(chatId.toString(), Instant.now())
             return
         }
 
@@ -63,19 +64,19 @@ class KotlinMentionsProcessor(
             return
         }
 
-        val stickerMsg = sendSticker(contentMessage.chat.id, contentMessage.messageId)
-        bot.sendTextMessage(contentMessage.chat.id,
+        val stickerMsg = sendSticker(chatId, contentMessage.messageId)
+        bot.sendTextMessage(chatId.toChatId(),
                 composeStickerMessage(duration),
                 replyToMessageId = stickerMsg.messageId)
 
-        kotlinMentionsDAO.updateKotlinLastMentionAt(id, Instant.now())
+        kotlinMentionsDAO.updateKotlinLastMentionAt(chatId.toString(), Instant.now())
     }
 
     private suspend fun sendSticker(
-            chatId: ChatId,
+            chatId: Identifier,
             messageId: MessageIdentifier
     ): ContentMessage<StickerContent> = bot.sendSticker(
-            chatId,
+            chatId.toChatId(),
             stickerFileId.toInputFile(),
             replyToMessageId = messageId
     )

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -85,7 +85,7 @@ class KotlinMentionsProcessor(
 
         onSend(response)
 
-        kotlinMentionsDAO.updateKotlinLastMentionAt(
+        kotlinMentionsDAO.updateKotlinMentionInfo(
                 chatId.toString(), userId.toString(), Instant.now())
     }
 }

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -83,6 +83,6 @@ class KotlinMentionsProcessor(
         onSend(response)
 
         kotlinMentionsDAO.updateKotlinMentionInfo(
-                chatId.toString(), userId.toString(), Instant.now())
+                chatId.toString(), userId.toString())
     }
 }

--- a/src/test/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessorTest.kt
+++ b/src/test/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessorTest.kt
@@ -8,9 +8,12 @@ import com.github.insanusmokrassar.TelegramBotAPI.requests.abstracts.Request
 import com.github.insanusmokrassar.TelegramBotAPI.requests.abstracts.toInputFile
 import com.github.insanusmokrassar.TelegramBotAPI.types.ChatId
 import com.github.insanusmokrassar.TelegramBotAPI.types.ChatIdentifier
+import com.github.insanusmokrassar.TelegramBotAPI.types.CommonUser
+import com.github.insanusmokrassar.TelegramBotAPI.types.TelegramDate
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageIdentifier
 import com.github.insanusmokrassar.TelegramBotAPI.types.chat.GroupChatImpl
-import com.github.insanusmokrassar.TelegramBotAPI.types.chat.abstracts.Chat
+import com.github.insanusmokrassar.TelegramBotAPI.types.message.AnonymousForwardInfo
+import com.github.insanusmokrassar.TelegramBotAPI.types.message.CommonMessageImpl
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.abstracts.ContentMessage
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextContent
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.media.StickerContent
@@ -47,6 +50,7 @@ class KotlinMentionsProcessorTest {
     @RelaxedMockK
     private lateinit var kotlinMentionsDAOMock: KotlinMentionsDAO
     private val expectedChatId = ChatId(1L)
+    private val expectedUserId = CommonUser(ChatId(1L), "soprano")
     private val expectedStickerMessageId: MessageIdentifier = 1L
     private val expectedPeriodReplyMessageId: MessageIdentifier = 2L
     private val expectedStickerFileId = KotlinMentionsProcessor.zeroDaysWithoutKotlinStickerFileId.toInputFile()
@@ -174,15 +178,14 @@ class KotlinMentionsProcessorTest {
     }
 
     private fun mockMessage(text: String): ContentMessage<TextContent> {
-        return object : ContentMessage<TextContent> {
-            override val chat: Chat
-                get() = GroupChatImpl(expectedChatId, "jprofby")
-            override val content: TextContent
-                get() = TextContent(text)
-            override val date: DateTime
-                get() = DateTime.now()
-            override val messageId: MessageIdentifier
-                get() = expectedStickerMessageId
-        }
+        return CommonMessageImpl(
+                expectedStickerMessageId,
+                expectedUserId,
+                GroupChatImpl(expectedChatId, "jprofby"),
+                TextContent(text),
+                DateTime.now(),
+                DateTime.now(),
+                AnonymousForwardInfo(TelegramDate(DateTime.now()), "unknown"),
+                null, null, null, null)
     }
 }

--- a/src/test/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessorTest.kt
+++ b/src/test/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessorTest.kt
@@ -53,7 +53,7 @@ class KotlinMentionsProcessorTest {
     private val expectedUserId = CommonUser(ChatId(1L), "soprano")
     private val expectedStickerMessageId: MessageIdentifier = 1L
     private val expectedPeriodReplyMessageId: MessageIdentifier = 2L
-    private val expectedStickerFileId = KotlinMentionsProcessor.zeroDaysWithoutKotlinStickerFileId.toInputFile()
+    private val expectedStickerFileId = "CAACA".toInputFile()
 
     @BeforeEach
     fun setUp() {
@@ -152,7 +152,9 @@ class KotlinMentionsProcessorTest {
     }
 
     private suspend fun processUpdate(message: String) {
-        val processor = KotlinMentionsProcessor(reqExecutorMock, kotlinMentionsDAOMock)
+        val processor = KotlinMentionsProcessor(
+                reqExecutorMock, kotlinMentionsDAOMock,
+                stickerFileId = expectedStickerFileId.fileId)
         processor.process(MessageUpdate(1L, mockMessage(message)))
     }
 


### PR DESCRIPTION
By this PR we introduce initial infrastructure to collect user's mention statistics: count and last mention time. It's a first step of introduction `/kotlins-stats` bot command.

I going to re-user `kotlin-mentions` table by introducing one more `users` map attribute to keep per-user information