### PR TITLE
A delay of 2 seconds in sending duration message

### DIFF
--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -12,8 +12,10 @@ import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextCont
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.media.StickerContent
 import com.github.insanusmokrassar.TelegramBotAPI.types.update.MessageUpdate
 import com.github.insanusmokrassar.TelegramBotAPI.types.update.abstracts.Update
+import kotlinx.coroutines.time.delay
 import java.time.Duration
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlin.random.Random
 
 class KotlinMentionsProcessor(
@@ -63,6 +65,7 @@ class KotlinMentionsProcessor(
         }
 
         val stickerMsg = sendSticker(contentMessage.chat.id, contentMessage.messageId)
+        delay(Duration.of(2, ChronoUnit.SECONDS))
         bot.sendTextMessage(contentMessage.chat.id,
                 composeStickerMessage(duration),
                 replyToMessageId = stickerMsg.messageId)


### PR DESCRIPTION
Recently we experienced strange behavior in how lambda process messages: duration message wasn't sent as expected in certain random cases. A potential reason is throttling on the telegram side. By this PR we introduce some delay of seconds in sending duration message. Please. find below the related debug information:
```
thrown.extendedStackTrace.16  
{"class":"com.github.insanusmokrassar.TelegramBotAPI.bot.Ktor.KtorRequestsExecutor$execute$3$1","method":"invokeSuspend","file":"KtorRequestsExecutor.kt","line":102,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.17  
{"class":"kotlin.coroutines.jvm.internal.BaseContinuationImpl","method":"resumeWith","file":"ContinuationImpl.kt","line":33,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.18  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"resumeRootWith","file":"PipelineContext.kt","line":238,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.19  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"loop","file":"PipelineContext.kt","line":194,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.20  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"access$loop","file":"PipelineContext.kt","line":67,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.21  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun$continuation$1","method":"resumeWith","file":"PipelineContext.kt","line":144,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.22  
{"class":"kotlin.coroutines.jvm.internal.BaseContinuationImpl","method":"resumeWith","file":"ContinuationImpl.kt","line":46,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.23  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"resumeRootWith","file":"PipelineContext.kt","line":238,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.24  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"loop","file":"PipelineContext.kt","line":194,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.25  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"access$loop","file":"PipelineContext.kt","line":67,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.26  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun$continuation$1","method":"resumeWith","file":"PipelineContext.kt","line":144,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.27  
{"class":"kotlin.coroutines.jvm.internal.BaseContinuationImpl","method":"resumeWith","file":"ContinuationImpl.kt","line":46,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.28  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"resumeRootWith","file":"PipelineContext.kt","line":238,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.29  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"loop","file":"PipelineContext.kt","line":194,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.30  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"access$loop","file":"PipelineContext.kt","line":67,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.31  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun$continuation$1","method":"resumeWith","file":"PipelineContext.kt","line":144,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.32  
{"class":"kotlin.coroutines.jvm.internal.BaseContinuationImpl","method":"resumeWith","file":"ContinuationImpl.kt","line":46,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.33  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"resumeRootWith","file":"PipelineContext.kt","line":238,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.34  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"loop","file":"PipelineContext.kt","line":194,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.35  
{"class":"io.ktor.util.pipeline.SuspendFunctionGun","method":"access$loop","file":"PipelineContext.kt","line":67,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.36

{"class":"io.ktor.util.pipeline.SuspendFunctionGun$continuation$1","method":"resumeWith","file":"PipelineContext.kt","line":144,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.37  
{"class":"kotlin.coroutines.jvm.internal.BaseContinuationImpl","method":"resumeWith","file":"ContinuationImpl.kt","line":46,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.38  
{"class":"kotlinx.coroutines.DispatchedTask","method":"run","file":"DispatchedTask.kt","line":56,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.39  
{"class":"kotlinx.coroutines.EventLoopImplBase","method":"processNextEvent","file":"EventLoop.common.kt","line":272,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.40  
{"class":"kotlinx.coroutines.BlockingCoroutine","method":"joinBlocking","file":"Builders.kt","line":79,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.41  
{"class":"kotlinx.coroutines.BuildersKt__BuildersKt","method":"runBlocking","file":"Builders.kt","line":54,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.42  
{"class":"kotlinx.coroutines.BuildersKt","method":"runBlocking","line":1,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.43  
{"class":"kotlinx.coroutines.BuildersKt__BuildersKt","method":"runBlocking$default","file":"Builders.kt","line":36,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.44  
{"class":"kotlinx.coroutines.BuildersKt","method":"runBlocking$default","line":1,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.45  
{"class":"by.jprof.telegram.opinions.processors.UpdateProcessingPipeline","method":"process","file":"UpdateProcessingPipeline.kt","line":19,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.46  
{"class":"by.jprof.telegram.opinions.Handler","method":"handleRequest","file":"Handler.kt","line":49,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.47  
{"class":"by.jprof.telegram.opinions.Handler","method":"handleRequest","file":"Handler.kt","line":28,"exact":true,"location":"task/","version":"?"}
thrown.extendedStackTrace.48  
{"class":"lambdainternal.EventHandlerLoader$PojoHandlerAsStreamHandler","method":"handleRequest","file":"EventHandlerLoader.java","line":199,"exact":true,"location":"aws-lambda-java-runtime-0.2.0.jar","version":"?"}
thrown.extendedStackTrace.49  
{"class":"lambdainternal.EventHandlerLoader$2","method":"call","file":"EventHandlerLoader.java","line":899,"exact":true,"location":"aws-lambda-java-runtime-0.2.0.jar","version":"?"}
thrown.extendedStackTrace.50  
{"class":"lambdainternal.AWSLambda","method":"startRuntime","file":"AWSLambda.java","line":258,"exact":true,"location":"aws-lambda-java-runtime-0.2.0.jar","version":"?"}
thrown.extendedStackTrace.51  
{"class":"lambdainternal.AWSLambda","method":"startRuntime","file":"AWSLambda.java","line":192,"exact":true,"location":"aws-lambda-java-runtime-0.2.0.jar","version":"?"}
thrown.extendedStackTrace.52  
{"class":"lambdainternal.AWSLambda","method":"main","file":"AWSLambda.java","line":187,"exact":true,"location":"aws-lambda-java-runtime-0.2.0.jar","version":"?"}
thrown.localizedMessage  
Can't get result object from {"ok":false,"error_code":429,"description":"Too Many Requests: retry after 12","parameters":{"retry_after":12}}
thrown.message  
Can't get result object from {"ok":false,"error_code":429,"description":"Too Many Requests: retry after 12","parameters":{"retry_after":12}}
thrown.name  
com.github.insanusmokrassar.TelegramBotAPI.bot.exceptions.CommonRequestException
```