### PR TITLE
Decouple sticker sending throttling and kotlin mention stats updating

### DIFF
--- a/src/main/kotlin/by/jprof/telegram/opinions/entity/Mentions.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/entity/Mentions.kt
@@ -31,11 +31,11 @@ data class KotlinMention(
         )
     }
 
-    fun update(userId: Long, timestamp: Instant): KotlinMention {
+    fun updateUserStats(userId: Long): KotlinMention {
         val updatedUsers = users.toMutableMap()
         val stats = updatedUsers[userId] ?: MentionStats(0, Instant.now())
         updatedUsers[userId] = MentionStats(stats.count + 1, Instant.now())
-        return copy(users = updatedUsers, timestamp = timestamp)
+        return copy(users = updatedUsers)
     }
 
     fun toAttrs(): Map<String, AttributeValue> = mapOf<String, AttributeValue>(

--- a/src/test/kotlin/by/jprof/telegram/opinions/entity/KotlinMentionTest.kt
+++ b/src/test/kotlin/by/jprof/telegram/opinions/entity/KotlinMentionTest.kt
@@ -16,7 +16,7 @@ internal class KotlinMentionTest {
         val now = Instant.now()
         val mention = KotlinMention(1, now, mapOf(111L to MentionStats(1, Instant.now())))
         TimeUnit.MILLISECONDS.sleep(1) // to ensure lastUpdatedAt > now
-        val updatedMention = mention.update(111L, now)
+        val updatedMention = mention.updateUserStats(111L)
         assertEquals(1, updatedMention.users.size)
         val (count, lastUpdatedAt) = updatedMention.users[111L] ?: fail("user")
         assertEquals(2, count)


### PR DESCRIPTION
I guess we do not actually need limit accumulating mentioning stats, let's allow users to gather points as much as they want. Throttling is really mattered for sticker sending.