### PR TITLE
Feature/kotlin mention processor shouldnt handle bot commands

### DIFF
--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessor.kt
@@ -9,10 +9,12 @@ import com.github.insanusmokrassar.TelegramBotAPI.extensions.api.send.media.send
 import com.github.insanusmokrassar.TelegramBotAPI.extensions.api.send.sendTextMessage
 import com.github.insanusmokrassar.TelegramBotAPI.requests.abstracts.toInputFile
 import com.github.insanusmokrassar.TelegramBotAPI.types.ChatId
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.BotCommandTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageIdentifier
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.CommonMessageImpl
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.abstracts.ContentMessage
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextContent
+import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.fullEntitiesList
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.media.PhotoContent
 import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.media.StickerContent
 import com.github.insanusmokrassar.TelegramBotAPI.types.toChatId
@@ -80,12 +82,15 @@ class KotlinMentionsProcessor(
 
     private suspend fun containsMatchIn(contentMessage: ContentMessage<*>): Boolean {
         val content = contentMessage.content
-        return (content is TextContent) && containsInText(content.text)
-                || (content is PhotoContent) && containsInImage(content)
+        return ((content is TextContent) && !hasCommand(content) && containsInText(content.text))
+                || ((content is PhotoContent) && containsInImage(content))
     }
 
     private fun containsInText(text: String): Boolean =
             kotlinRegex.containsMatchIn(text)
+
+    private fun hasCommand(textContent: TextContent): Boolean =
+            textContent.fullEntitiesList().any { it is BotCommandTextSource }
 
     private suspend fun containsInImage(photoContent: PhotoContent): Boolean {
         val fileInfo = bot.getFileAdditionalInfo(photoContent.media.fileId)

--- a/src/test/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessorTest.kt
+++ b/src/test/kotlin/by/jprof/telegram/opinions/processors/KotlinMentionsProcessorTest.kt
@@ -186,7 +186,7 @@ class KotlinMentionsProcessorTest {
     @Test
     fun `test without kotlin mentioning then sticker shouldn't be sent`() = runBlocking {
         processUpdate("Любимый вопрос после собеса \"Часто ли пользуетесь тем о чем сейчас спрашивали?\"")
-        coVerify { reqExecutorMock.execute(any<Request<*>>()) wasNot Called }
+        coVerify(exactly = 0) { reqExecutorMock.sendSticker(any(), any(), replyToMessageId = any()) }
     }
 
     private suspend fun processUpdate(message: String) {


### PR DESCRIPTION
A small improvement to ignore bot commands when updating user kotlin mention statistics. Fixed a broken test 