### PR TITLE
Fix/deployment optimiation

### DIFF
--- a/.cdk/lib/opinions-stack.ts
+++ b/.cdk/lib/opinions-stack.ts
@@ -25,6 +25,12 @@ export class OpinionsStack extends cdk.Stack {
 			billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
 		});
 
+		const layer = new lambda.LayerVersion(this, 'Opinions Layer', {
+			code: lambda.Code.fromAsset('../build/layer.zip'),
+			compatibleRuntimes: [lambda.Runtime.JAVA_11],
+			description: 'Heavy resources(tesseract, etc) to reduce bundle size',
+		});
+
 		const lambdaFunctionWebhook = new lambda.Function(this, 'opinions-webhook', {
 			functionName: 'opinions-webhook',
 			runtime: lambda.Runtime.JAVA_11,
@@ -39,7 +45,8 @@ export class OpinionsStack extends cdk.Stack {
 				'TABLE_VOTES': votestTable.tableName,
 				'TABLE_YOUTUBE_CHANNELS_WHITELIST': youtubeChannelsWhitelistTable.tableName,
 				'TABLE_KOTLIN_MENTIONS': kotlinMentionsTable.tableName,
-			}
+			},
+			layers: [layer]
 		});
 
 		votestTable.grantReadWriteData(lambdaFunctionWebhook);

--- a/.cdk/lib/opinions-stack.ts
+++ b/.cdk/lib/opinions-stack.ts
@@ -45,6 +45,7 @@ export class OpinionsStack extends cdk.Stack {
 				'TABLE_VOTES': votestTable.tableName,
 				'TABLE_YOUTUBE_CHANNELS_WHITELIST': youtubeChannelsWhitelistTable.tableName,
 				'TABLE_KOTLIN_MENTIONS': kotlinMentionsTable.tableName,
+				'OPINIONS_LAYER_PATH': '/opt/java/lib',
 			},
 			layers: [layer]
 		});

--- a/.cdk/lib/opinions-stack.ts
+++ b/.cdk/lib/opinions-stack.ts
@@ -35,7 +35,7 @@ export class OpinionsStack extends cdk.Stack {
 			functionName: 'opinions-webhook',
 			runtime: lambda.Runtime.JAVA_11,
 			timeout: Duration.seconds(30),
-			memorySize: 512,
+			memorySize: 1024,
 			code: lambda.Code.fromAsset('../build/libs/opinions-bot-all.jar'),
 			handler: 'by.jprof.telegram.opinions.Handler',
 			environment: {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("com.google.api-client:google-api-client:1.23.0")
     implementation("com.google.apis:google-api-services-youtube:v3-rev222-1.25.0")
     implementation("com.github.insanusmokrassar:TelegramBotAPI-all:0.27.11")
-    implementation("org.bytedeco.javacpp-presets:tesseract-platform:4.0.0-1.4.4")
+    implementation("org.bytedeco:tesseract-platform:4.0.0-1.5")
 
     testImplementation(platform("org.junit:junit-bom:5.6.0"))
     testRuntimeOnly(platform("org.junit:junit-bom:5.6.0"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,13 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.internal.os.OperatingSystem;
+
+val os = OperatingSystem.current()
+// javacpp use "x86_64" name for "amd64"
+val nativePrefix = os.nativePrefix.replace("amd64", "x86_64")
+val tesseractVersion = "4.0.0-1.5"
+val leptonicaVersion = "1.78.0-1.5"
 
 plugins {
     kotlin("jvm").version("1.3.71")
@@ -43,7 +50,10 @@ dependencies {
     implementation("com.google.api-client:google-api-client:1.23.0")
     implementation("com.google.apis:google-api-services-youtube:v3-rev222-1.25.0")
     implementation("com.github.insanusmokrassar:TelegramBotAPI-all:0.27.11")
-    implementation("org.bytedeco:tesseract-platform:4.0.0-1.5")
+    implementation("org.bytedeco", "tesseract", version = tesseractVersion, classifier = nativePrefix)
+    implementation("org.bytedeco", "tesseract", version = tesseractVersion)
+    implementation("org.bytedeco", "leptonica", version = leptonicaVersion, classifier = nativePrefix)
+    implementation("org.bytedeco", "leptonica", version = leptonicaVersion)
 
     testImplementation(platform("org.junit:junit-bom:5.6.0"))
     testRuntimeOnly(platform("org.junit:junit-bom:5.6.0"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.internal.os.OperatingSystem
 
 plugins {
     kotlin("jvm").version("1.3.71")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,10 @@ tasks {
     }
     val shadowJar by getting(ShadowJar::class) {
         transform(Log4j2PluginsCacheFileTransformer::class.java)
+        filesMatching("**/tessdata") {
+            exclude()
+        }
+        dependsOn("layer")
     }
     test {
         useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,15 +3,10 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCach
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.gradle.internal.os.OperatingSystem
 
-val os = OperatingSystem.current()
-// javacpp use "x86_64" name for "amd64"
-val nativePrefix = os.nativePrefix.replace("amd64", "x86_64")
-val tesseractVersion = "4.0.0-1.5"
-val leptonicaVersion = "1.78.0-1.5"
-
 plugins {
     kotlin("jvm").version("1.3.71")
     id("com.github.johnrengelman.shadow").version("5.2.0")
+    id("org.bytedeco.gradle-javacpp-platform").version("1.5.4-SNAPSHOT")
 }
 
 repositories {
@@ -50,10 +45,7 @@ dependencies {
     implementation("com.google.api-client:google-api-client:1.23.0")
     implementation("com.google.apis:google-api-services-youtube:v3-rev222-1.25.0")
     implementation("com.github.insanusmokrassar:TelegramBotAPI-all:0.27.11")
-    implementation("org.bytedeco", "tesseract", version = tesseractVersion, classifier = nativePrefix)
-    implementation("org.bytedeco", "tesseract", version = tesseractVersion)
-    implementation("org.bytedeco", "leptonica", version = leptonicaVersion, classifier = nativePrefix)
-    implementation("org.bytedeco", "leptonica", version = leptonicaVersion)
+    implementation("org.bytedeco:tesseract-platform:4.0.0-1.5")
 
     testImplementation(platform("org.junit:junit-bom:5.6.0"))
     testRuntimeOnly(platform("org.junit:junit-bom:5.6.0"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.os.OperatingSystem
 
 val os = OperatingSystem.current()
 // javacpp use "x86_64" name for "amd64"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,9 +62,7 @@ tasks {
     }
     val shadowJar by getting(ShadowJar::class) {
         transform(Log4j2PluginsCacheFileTransformer::class.java)
-        filesMatching("**/tessdata") {
-            exclude()
-        }
+        exclude("**/tessdata/")
         dependsOn("layer")
     }
     test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,4 +66,14 @@ tasks {
     test {
         useJUnitPlatform()
     }
+    register<Copy>("copyLayer") {
+        from("src/main/resources/tessdata/")
+        into("$buildDir/layer/java/lib")
+    }
+    register<Zip>("layer") {
+        dependsOn("copyLayer")
+        archiveFileName.set("layer.zip")
+        destinationDirectory.set(file(buildDir))
+        from("$buildDir/layer")
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
+    }
+}
+
 rootProject.name = "opinions-bot"

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/Tesseract.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/Tesseract.kt
@@ -20,10 +20,14 @@ enum class Lang(val label: String) {
 
 class Tesseract(private val tessdatasrc: String = "tessdata") {
     companion object {
-        private fun copyTessdata(tessdatapath: String, dest: File) {
+        private fun copyTessdata(tessdatapath: String, destdir: File) {
+            val cl = this::class.java.classLoader
             Lang.values().forEach { lang ->
-                this::class.java.classLoader.getResource("${tessdatapath}/${lang.label}.traineddata")?.openStream()?.use {
-                    it.transferTo(FileOutputStream(File(dest, "${lang.label}.traineddata")))
+                val name = "${lang.label}.traineddata"
+                val from = "${tessdatapath}/$name"
+                val to = File(destdir, name)
+                cl.getResource(from)?.openStream()?.use {
+                    it.copyTo(FileOutputStream(to))
                 }
             }
         }

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/Tesseract.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/Tesseract.kt
@@ -1,7 +1,13 @@
 package by.jprof.telegram.opinions.processors
 
-import org.bytedeco.javacpp.lept
-import org.bytedeco.javacpp.tesseract
+import org.bytedeco.leptonica.global.lept.pixRead
+import org.bytedeco.tesseract.TessBaseAPI
+import org.bytedeco.tesseract.global.tesseract
+import org.bytedeco.tesseract.global.tesseract.TessBaseAPIGetIterator
+import org.bytedeco.tesseract.global.tesseract.TessBaseAPIInit2
+import org.bytedeco.tesseract.global.tesseract.TessBaseAPIRecognize
+import org.bytedeco.tesseract.global.tesseract.TessBaseAPISetImage2
+import org.bytedeco.tesseract.global.tesseract.TessResultIteratorGetUTF8Text
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -27,13 +33,13 @@ class Tesseract(private val tessdatasrc: String = "tessdata") {
 
     fun ocr(imgFile: File, lang: Lang): String {
         ensureTessdata()
-        return tesseract.TessBaseAPI().use { api ->
-            tesseract.TessBaseAPIInit2(api, tessdata.toString(), lang.label, tesseract.OEM_DEFAULT)
-            lept.pixRead(imgFile.absolutePath).use { img ->
-                tesseract.TessBaseAPISetImage2(api, img)
-                tesseract.TessBaseAPIRecognize(api, null/*monitor*/)
-                tesseract.TessBaseAPIGetIterator(api).use { resultIter ->
-                    tesseract.TessResultIteratorGetUTF8Text(resultIter, tesseract.RIL_BLOCK).use { bytes ->
+        return TessBaseAPI().use { api ->
+            TessBaseAPIInit2(api, tessdata.toString(), lang.label, tesseract.OEM_DEFAULT)
+            pixRead(imgFile.absolutePath).use { img ->
+                TessBaseAPISetImage2(api, img)
+                TessBaseAPIRecognize(api, null/*monitor*/)
+                TessBaseAPIGetIterator(api).use { resultIter ->
+                    TessResultIteratorGetUTF8Text(resultIter, tesseract.RIL_BLOCK).use { bytes ->
                         String(bytes.stringBytes, StandardCharsets.UTF_8)
                     }
                 }

--- a/src/main/kotlin/by/jprof/telegram/opinions/processors/Tesseract.kt
+++ b/src/main/kotlin/by/jprof/telegram/opinions/processors/Tesseract.kt
@@ -48,15 +48,26 @@ class Tesseract(private val tessdatasrc: String = "tessdata") {
     }
 
     private fun ensureTessdata() {
-        if (!this::tessdata.isInitialized) {
-            tessdata = Files.createTempDirectory("jprof-ocr").toFile()
-            tessdata.deleteOnExit()
-            copyTessdata(tessdatasrc, tessdata)
+        if (this::tessdata.isInitialized) {
+            check(tessdata)
+            return
         }
-        check()
+
+        // if tess data already prepared - use it
+        System.getenv("OPINIONS_LAYER_PATH")?.let {
+            tessdata = File(it)
+            check(tessdata)
+            return
+        }
+
+        // otherwise try to find them among resources
+        tessdata = Files.createTempDirectory("jprof-ocr").toFile()
+        tessdata.deleteOnExit()
+        copyTessdata(tessdatasrc, tessdata)
+        check(tessdata)
     }
 
-    private fun check() {
+    private fun check(tessdata: File) {
         if (!tessdata.isDirectory) {
             throw IOException("'tessdata' exists but is not a directory")
         }


### PR DESCRIPTION
Should fix #18 issue

I filter out unused dependencies using classifiers. I tried to play around gradle-javacpp plugin but seems it doesn't work with kotlin gradle dsl, no idea why. I raised an [issue](https://github.com/bytedeco/gradle-javacpp/issues/2) 

Current build size 47M:
```
$ du -sh build/libs/opinions-bot-all.jar 
47M     build/libs/opinions-bot-all.jar
```